### PR TITLE
Resolve user and channel names

### DIFF
--- a/lib/medera/slack.ex
+++ b/lib/medera/slack.ex
@@ -43,12 +43,15 @@ defmodule Medera.Slack do
 
   # should only be used in tests to simulate receiving a message
   @doc false
-  @spec receive_event(map | Event.t) :: :ok
+  @spec receive_event(Event.t) :: :ok
   def receive_event(event = %Event{}) do
     GenServer.call(__MODULE__, {:receive_event, event})
   end
-  def receive_event(event = %{}) do
-    receive_event(Event.from_slack(event))
+
+  @doc false
+  @spec receive_event(map, map) :: :ok
+  def receive_event(event = %{}, extra \\ %{}) when is_map(extra) do
+    receive_event(Event.from_slack(event, extra))
   end
 
   ######################################################################

--- a/lib/medera/slack/connector.ex
+++ b/lib/medera/slack/connector.ex
@@ -8,6 +8,7 @@ defmodule Medera.Slack.Connector do
 
   alias Slack.Bot
   alias Slack.Sends
+  alias Slack.Lookups
 
   use Slack
 
@@ -22,8 +23,12 @@ defmodule Medera.Slack.Connector do
   end
 
   @doc false
-  def handle_event(event, _slack, state) do
-    :ok = MederaSlack.receive_event(event)
+  def handle_event(event, slack, state) do
+    :ok = event
+    |> resolve_user(slack)
+    |> resolve_channel(slack)
+    |> MederaSlack.receive_event
+
     {:ok, state}
   end
 
@@ -36,4 +41,32 @@ defmodule Medera.Slack.Connector do
     Logger.warn("#{__MODULE__} is ignoring unexpected message #{inspect msg}")
     {:ok, process_state}
   end
+
+  # `:user` is a slack id - this resolves that to a human-readable
+  #    user id if one is available
+  defp resolve_user(event = %{user: user}, slack) do
+    Map.put(event, :human_user, Lookups.lookup_user_name(user, slack))
+  end
+  defp resolve_user(event, _), do: event
+
+  # `:channel` is a slack id - this resolves that to a human-readable
+  #    channel name if one is available and marks the message as a DM if it is
+  defp resolve_channel(event = %{channel: channel}, slack) do
+    case channel do
+      # channel
+      "C" <> _ ->
+        Map.put(
+          event,
+          :human_channel,
+          Lookups.lookup_channel_name(channel, slack)
+        )
+      # direct message
+      "D" <> _ ->
+        event
+        |> Map.put(:human_channel, Lookups.lookup_user_name(channel, slack))
+        |> Map.put(:direct_message, true)
+    end
+  end
+  defp resolve_channel(event, _), do: event
+
 end

--- a/lib/medera/slack/event.ex
+++ b/lib/medera/slack/event.ex
@@ -5,7 +5,7 @@ defmodule Medera.Slack.Event do
   An Event struct always contains the original payload from Slack in the
   payload field.  Some fields are "promoted" to the top level of the struct
   if they are present:
-  
+
   * `type` - The event type
   * `user` - Slack user id
   * `channel` - Slack channel id (may be a direct message)

--- a/lib/medera/slack/event.ex
+++ b/lib/medera/slack/event.ex
@@ -1,19 +1,33 @@
 defmodule Medera.Slack.Event do
   @moduledoc """
   Represents an event we receive from Slack
+
+  An Event struct always contains the original payload from Slack in the
+  payload field.  Some fields are "promoted" to the top level of the struct
+  if they are present:
+  
+  * `type` - The event type
+  * `user` - Slack user id
+  * `channel` - Slack channel id (may be a direct message)
+  * `payload` - The original struct recieved
+
+  The following fields may be prepopulated if they were available and
+  applicable:
+  * `human_user` - Human-readable user name
+  * `human_channel` - Human-readable channel
+  * `direct_message` - `true` if the event was a direct message
   """
 
   require Logger
 
   defstruct(
     type: nil,
-    text: nil,
-    ts: nil,
     user: nil,
     human_user: nil,
     channel: nil,
     human_channel: nil,
-    direct_message: false
+    direct_message: false,
+    payload: nil
   )
   @type t :: %__MODULE__{}
 
@@ -21,37 +35,22 @@ defmodule Medera.Slack.Event do
 
   @doc """
   Convert from the bare map we get from the slack bot
+
+  `extra` contains extra lookup data that was not part of the original payload
   """
-  @spec from_slack(map) :: t
-  def from_slack(event) do
+  @spec from_slack(map, map) :: t
+  def from_slack(event, extra) do
     %Event{
-      type: event_type(event),
-      direct_message: Map.get(event, :direct_message, false),
+      type: Map.get(event, :type),
+      direct_message: Map.get(extra, :direct_message, false),
       # these might not be set, so use Map.get which will safely set them to
       # nil if they are not present
       channel: Map.get(event, :channel),
-      human_channel: Map.get(event, :channel),
-      text: Map.get(event, :text),
-      ts: Map.get(event, :ts),
+      human_channel: Map.get(extra, :channel),
       user: Map.get(event, :user),
-      human_user: Map.get(event, :human_user)
+      human_user: Map.get(extra, :human_user),
+      payload: event
     }
   end
-
-  # determine the event type
-  defp event_type(%{type: "message"}),         do: :message
-  # sent when we first connect
-  defp event_type(%{type: "hello"}),           do: :hello
-  # when a user is setting/unsetting 'away'
-  defp event_type(%{type: "presence_change"}), do: :presence_change
-  # user opens a direct message channel
-  defp event_type(%{type: "im_open"}),         do: :im_open
-  # experimental: http://api.slack.com/events/reconnect_url
-  defp event_type(%{type: "reconnect_url"}),   do: :reconnect_url
-  defp event_type(event) do
-    Logger.debug("Received unkown type of event: #{inspect event}")
-    :unknown
-  end
 end
-
 

--- a/lib/medera/slack/event.ex
+++ b/lib/medera/slack/event.ex
@@ -10,7 +10,10 @@ defmodule Medera.Slack.Event do
     text: nil,
     ts: nil,
     user: nil,
-    channel: nil
+    human_user: nil,
+    channel: nil,
+    human_channel: nil,
+    direct_message: false
   )
   @type t :: %__MODULE__{}
 
@@ -23,12 +26,15 @@ defmodule Medera.Slack.Event do
   def from_slack(event) do
     %Event{
       type: event_type(event),
+      direct_message: Map.get(event, :direct_message, false),
       # these might not be set, so use Map.get which will safely set them to
       # nil if they are not present
       channel: Map.get(event, :channel),
+      human_channel: Map.get(event, :channel),
       text: Map.get(event, :text),
       ts: Map.get(event, :ts),
-      user: Map.get(event, :user)
+      user: Map.get(event, :user),
+      human_user: Map.get(event, :human_user)
     }
   end
 
@@ -38,6 +44,8 @@ defmodule Medera.Slack.Event do
   defp event_type(%{type: "hello"}),           do: :hello
   # when a user is setting/unsetting 'away'
   defp event_type(%{type: "presence_change"}), do: :presence_change
+  # user opens a direct message channel
+  defp event_type(%{type: "im_open"}),         do: :im_open
   # experimental: http://api.slack.com/events/reconnect_url
   defp event_type(%{type: "reconnect_url"}),   do: :reconnect_url
   defp event_type(event) do

--- a/lib/medera/slack/handler.ex
+++ b/lib/medera/slack/handler.ex
@@ -36,12 +36,18 @@ defmodule Medera.Slack.Handler do
   @spec handle_event(Event.t) :: return_t
   def handle_event(event = %Event{}) do
     case event do
-      %Event{type: :message} -> handle_message(event)
+      %Event{type: "message"} -> handle_message(event)
       _ -> :ok  # unhandled event type - ok for now
     end
   end
 
-  defp handle_message(%Event{text: text, channel: channel, type: :message}) do
+  defp handle_message(
+    %Event{
+      channel: channel,
+      type: "message",
+      payload: %{text: text}
+    }
+  ) do
     if text && text == "Hi" do
       {:ok, {:reply, "Hello, there!", channel}}
     else

--- a/test/medera/slack/handler_test.exs
+++ b/test/medera/slack/handler_test.exs
@@ -5,9 +5,11 @@ defmodule Medera.Slack.HandlerTest do
 
   alias Medera.Slack.Event
 
+  defdelegate event(payload, extra \\ %{}), to: Event, as: :from_slack
+
   test "replies to 'Hi'" do
     channel = "#test"
-    message = %Event{text: "Hi", channel: channel, type: :message}
+    message = event(%{text: "Hi", type: "message", channel: channel})
     assert {:ok, {:reply, _, ^channel}} =
       Medera.Slack.Handler.handle_event(message)
   end


### PR DESCRIPTION
Look up the human-readable user and channel names and insert them into the `%Event{}` struct.