### PR TITLE
Add Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: elixir
+otp_release:
+  - 19.2
+elixir:
+  - 1.4.0
+  - 1.3.4
+dist: trusty
+sudo: required
+services:
+  - postgresql
+script:
+  - MIX_ENV=test mix deps.compile
+  - mix test

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,4 @@ services:
 script:
   - MIX_ENV=test mix deps.compile
   - mix test
+  - mix credo --strict

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,4 +11,4 @@ services:
 script:
   - MIX_ENV=test mix deps.compile
   - mix test
-  - mix credo --strict
+  - MIX_ENV=test mix credo --strict


### PR DESCRIPTION
We kind of discussed moving to travis.  The build is a bit faster (< 2 minutes) and this would open us up to some standard integrations like coveralls and ebert (which can do credo).